### PR TITLE
feat: enhance markdown viewer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -82,6 +82,8 @@
   </footer>
 
   <!-- Script -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render markdown with marked and sanitize using DOMPurify
- allow navigating between markdown files via internal links
- add clickable headings with hash support

## Testing
- `node --check docs/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6078491f08325843545bbdc30feec