### PR TITLE
Agrupa archivos Markdown por carpeta en la vista de archivos

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -108,12 +108,46 @@ async function loadTree(){
 }
 function renderList(list){
   filelist.innerHTML = '';
+  const roots = [];
+  const dirs = {};
   list.forEach(p=>{
-    const li = document.createElement('li');
-    li.textContent = p;
-    li.onclick = ()=> { drawer.classList.remove('open'); openFile(p); };
-    filelist.appendChild(li);
+    if (!p.includes('/')) {
+      roots.push(p);
+    } else {
+      const [dir, ...rest] = p.split('/');
+      const name = rest.join('/');
+      if (!dirs[dir]) dirs[dir] = [];
+      dirs[dir].push(name);
+    }
   });
+  roots.sort((a,b)=>a.localeCompare(b,'es',{sensitivity:'base'}))
+    .forEach(p=>{
+      const li = document.createElement('li');
+      li.textContent = p;
+      li.onclick = ()=> { drawer.classList.remove('open'); openFile(p); };
+      filelist.appendChild(li);
+    });
+  Object.keys(dirs)
+    .sort((a,b)=>a.localeCompare(b,'es',{sensitivity:'base'}))
+    .forEach(dir=>{
+      const li = document.createElement('li');
+      li.className = 'folder-item';
+      const span = document.createElement('span');
+      span.textContent = dir;
+      span.className = 'folder';
+      li.appendChild(span);
+      const ul = document.createElement('ul');
+      dirs[dir]
+        .sort((a,b)=>a.localeCompare(b,'es',{sensitivity:'base'}))
+        .forEach(name=>{
+          const sub = document.createElement('li');
+          sub.textContent = name;
+          sub.onclick = ()=> { drawer.classList.remove('open'); openFile(dir + '/' + name); };
+          ul.appendChild(sub);
+        });
+      li.appendChild(ul);
+      filelist.appendChild(li);
+    });
 }
 async function openFile(path){
   currentPath = path;

--- a/docs/style.css
+++ b/docs/style.css
@@ -38,6 +38,10 @@ body{
 #filelist{list-style:none; margin:0; padding:.25rem; overflow:auto}
 #filelist li{padding:.4rem .5rem; border-radius:.4rem; cursor:pointer}
 #filelist li:hover{background:#23232b}
+#filelist li.folder-item{cursor:default}
+#filelist li.folder-item:hover{background:none}
+#filelist .folder{font-weight:700}
+#filelist ul{list-style:none; margin:0; padding-left:1rem}
 
 /* Panel Luna */
 #panel{


### PR DESCRIPTION
## Resumen
- Agrupa los .md de subdirectorios en la lista de archivos, manteniendo los de la raíz planos.
- Añade estilos para carpetas y listas anidadas en la vista.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba845e9d7483259126003ecd048289