### PR TITLE
Agrupa archivos Markdown y centra cabecera y pie

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS
+
+- Use 2 spaces for indentation in all files.
+- Run `npm test` before committing (current setup may not include a package.json; still run and report results).
+- When editing UI styles, keep the header and footer centered.

--- a/docs/app.js
+++ b/docs/app.js
@@ -108,12 +108,46 @@ async function loadTree(){
 }
 function renderList(list){
   filelist.innerHTML = '';
+  const roots = [];
+  const dirs = {};
   list.forEach(p=>{
-    const li = document.createElement('li');
-    li.textContent = p;
-    li.onclick = ()=> { drawer.classList.remove('open'); openFile(p); };
-    filelist.appendChild(li);
+    if (!p.includes('/')) {
+      roots.push(p);
+    } else {
+      const [dir, ...rest] = p.split('/');
+      const name = rest.join('/');
+      if (!dirs[dir]) dirs[dir] = [];
+      dirs[dir].push(name);
+    }
   });
+  roots.sort((a,b)=>a.localeCompare(b,'es',{sensitivity:'base'}))
+    .forEach(p=>{
+      const li = document.createElement('li');
+      li.textContent = p;
+      li.onclick = ()=> { drawer.classList.remove('open'); openFile(p); };
+      filelist.appendChild(li);
+    });
+  Object.keys(dirs)
+    .sort((a,b)=>a.localeCompare(b,'es',{sensitivity:'base'}))
+    .forEach(dir=>{
+      const li = document.createElement('li');
+      li.className = 'folder-item';
+      const span = document.createElement('span');
+      span.textContent = dir;
+      span.className = 'folder';
+      li.appendChild(span);
+      const ul = document.createElement('ul');
+      dirs[dir]
+        .sort((a,b)=>a.localeCompare(b,'es',{sensitivity:'base'}))
+        .forEach(name=>{
+          const sub = document.createElement('li');
+          sub.textContent = name;
+          sub.onclick = ()=> { drawer.classList.remove('open'); openFile(dir + '/' + name); };
+          ul.appendChild(sub);
+        });
+      li.appendChild(ul);
+      filelist.appendChild(li);
+    });
 }
 async function openFile(path){
   currentPath = path;

--- a/docs/style.css
+++ b/docs/style.css
@@ -14,9 +14,10 @@ body{
 /* Header */
 #topbar{
   position:sticky; top:0; z-index:5;
-  display:flex; align-items:center; gap:.75rem;
+  display:flex; align-items:center; gap:.75rem; justify-content:center;
   padding:.6rem .8rem; background:var(--panel);
   border-bottom:1px solid var(--line);
+  text-align:center;
 }
 #topbar #crumb{font-weight:700}
 #topbar button{
@@ -38,6 +39,10 @@ body{
 #filelist{list-style:none; margin:0; padding:.25rem; overflow:auto}
 #filelist li{padding:.4rem .5rem; border-radius:.4rem; cursor:pointer}
 #filelist li:hover{background:#23232b}
+#filelist li.folder-item{cursor:default}
+#filelist li.folder-item:hover{background:none}
+#filelist .folder{font-weight:700}
+#filelist ul{list-style:none; margin:0; padding-left:1rem}
 
 /* Panel Luna */
 #panel{
@@ -78,6 +83,7 @@ main{max-width:900px; margin:1rem auto 4rem; padding:0 1rem}
   position:fixed; left:0; right:0; bottom:0; z-index:5;
   background:var(--accent); color:#000; font-weight:800;
   display:flex; align-items:center; gap:1rem; padding:.4rem .7rem;
+  justify-content:center; text-align:center;
 }
 #progress{flex:1; height:6px; background:#0004; border-radius:999px; overflow:hidden}
 #bar{height:100%; width:0; background:#000; opacity:.6; transition:width .15s}


### PR DESCRIPTION
## Resumen
- Agrupa los .md de subdirectorios en la lista de archivos, manteniendo los de la raíz planos.
- Añade reglas para centrar el header y el footer en la interfaz.
- Crea `AGENTS.md` con pautas para futuras ediciones del repositorio.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba845e9d7483259126003ecd048289