### PR TITLE
Fix fallback repository name for markdown viewer

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -12,8 +12,8 @@ const [ownerGuess, repoGuess] = (() => {
   return [owner, repo];
 })();
 
-const REPO_OWNER = ownerGuess || 'imLeGEnDco55'; // fallback
-const REPO_NAME  = repoGuess  || 'ALMA45';       // fallback
+const REPO_OWNER = ownerGuess || 'imLeGEnDco55';  // fallback
+const REPO_NAME  = repoGuess  || 'ALMA4.5';       // fallback
 
 // ===== Helpers =====
 const $ = s => document.querySelector(s);


### PR DESCRIPTION
## Summary
- correct the fallback repository name used by the markdown viewer so it matches the actual ALMA4.5 repo
- ensure the app can load markdown files when hosted without owner/repo information in the URL

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f885aecf948325b4a660180ef22825